### PR TITLE
Re-Order imports to fix runtime error

### DIFF
--- a/eventelement.py
+++ b/eventelement.py
@@ -1,9 +1,11 @@
 from event import Event
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 from utils import get_glade_file_path
-import gi
+
 import json
-gi.require_version("Gtk", "3.0")
+
 
 
 class EventElement(Gtk.Box):


### PR DESCRIPTION
Error was popping up stating that Gtk was being used before it was assigned a version. Move the gi import and version statement above the Gtk import